### PR TITLE
Added .k to extension list

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
                 "extensions": [
                     ".c",
                     ".h",
-					".k"
+                    ".k"
                 ],
                 "configuration": "./kpl-language-configuration.json"
             },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
                 ],
                 "extensions": [
                     ".c",
-                    ".h"
+                    ".h",
+					".k"
                 ],
                 "configuration": "./kpl-language-configuration.json"
             },


### PR DESCRIPTION
At my university, we use .k for the KPL file extension. I added .k to the extensions list in package.json so syntax highlighting works for .k files.